### PR TITLE
New Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 *.prefs
 *.project
 *.classpath
+
+# Annoying macOS bullshit
+**.DS_Store

--- a/src/com/xarql/util/Zipper.java
+++ b/src/com/xarql/util/Zipper.java
@@ -2,10 +2,7 @@
 // No infringement intended
 package com.xarql.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -15,12 +12,15 @@ public class Zipper {
 	public static final int BUFFER_MULTIPLIER = 2;
 	public static final String ZIP_EXTENSION = ".zip";
 
-	public static void zip(final File input) throws IOException {
-		try(var fos = new FileOutputStream(input + ZIP_EXTENSION); var zipOut = new ZipOutputStream(fos)) {
+	public static File zip(final File input) throws IOException {
+		return zip(input, new File(input.getParentFile(), input.getName() + ZIP_EXTENSION));
+	}
+
+	public static File zip(final File input, final File output) throws IOException {
+		try(var fos = new FileOutputStream(output); var zipOut = new ZipOutputStream(fos)) {
 			zipFile(input, input.getName(), zipOut);
-		} catch(final IOException e) {
-			throw e;
 		}
+		return output;
 	}
 
 	private static void zipFile(final File fileToZip, final String fileName, final ZipOutputStream zipOut) throws IOException {

--- a/src/test/java/BaseConverterTest.java
+++ b/src/test/java/BaseConverterTest.java
@@ -5,37 +5,44 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaseConverterTest {
 
+    public static final int INNER_TEST_ITERATIONS = 128;
+
     @Test
-    public void testLowestInRange() {
+    public void testLowestInRange() throws InterruptedException {
         final ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         for (var a = 2; a <= BaseConverter.MAX_SUPPORTED_BASE; a++) {
             final int base = a;
             threadPool.execute(() -> {
-                // test the lowest 1024 numbers in the supported range
-                for (int num = 0; num < 1024; num++) {
+                // test the lowest 128 numbers in the supported range
+                for (int num = 0; num < INNER_TEST_ITERATIONS; num++) {
                     assertEquals(num, BaseConverter.toNumber(BaseConverter.toString(num, base), base));
                 }
             });
         }
+        threadPool.shutdown();
+        threadPool.awaitTermination(1000, TimeUnit.SECONDS);
     }
 
     @Test
-    public void testHighestInRangeTest() {
+    public void testHighestInRangeTest() throws InterruptedException {
         final ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         for (var a = 2; a <= BaseConverter.MAX_SUPPORTED_BASE; a++) {
             final int base = a;
             threadPool.execute(() -> {
-                // test the highest 1024 numbers in the supported range
-                for(int num = Integer.MAX_VALUE; num > Integer.MAX_VALUE - 1024; num--) {
+                // test the highest 128 numbers in the supported range
+                for(int num = Integer.MAX_VALUE; num > Integer.MAX_VALUE - INNER_TEST_ITERATIONS; num--) {
                     assertEquals(num, BaseConverter.toNumber(BaseConverter.toString(num, base), base));
                 }
             });
         }
+        threadPool.shutdown();
+        threadPool.awaitTermination(1000, TimeUnit.SECONDS);
     }
 
 }

--- a/src/test/java/CoverageRunner.java
+++ b/src/test/java/CoverageRunner.java
@@ -1,0 +1,18 @@
+package test.java;
+
+public class CoverageRunner {
+
+	public static void main(String[] args) throws Exception {
+		new BaseConverterTest().testHighestInRangeTest();
+		new BaseConverterTest().testLowestInRange();
+
+		new EncodeTest().testCar();
+		new MergeSortTest().testArray();
+		new NestedListTest().testParse();
+		new ParseTest().testCar();
+		new ParseUtilTest().testCar0();
+		new TemplateTest().testSimple();
+		new ZipperTest().testZipperWithOutputPath();
+	}
+
+}

--- a/src/test/java/CoverageRunner.java
+++ b/src/test/java/CoverageRunner.java
@@ -1,5 +1,7 @@
 package test.java;
 
+import com.xarql.util.Text;
+
 public class CoverageRunner {
 
 	public static void main(String[] args) throws Exception {
@@ -12,6 +14,9 @@ public class CoverageRunner {
 		new ParseTest().testCar();
 		new ParseUtilTest().testCar0();
 		new TemplateTest().testSimple();
+
+		TextTest.main(null);
+
 		new ZipperTest().testZipperWithOutputPath();
 	}
 

--- a/src/test/java/TextTest.java
+++ b/src/test/java/TextTest.java
@@ -1,0 +1,52 @@
+package test.java;
+
+import com.xarql.util.Text;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TextTest {
+
+	public static void main(String[] args) {
+		TextTest tester = new TextTest();
+		tester.test_a_z();
+		tester.test_a_zInvalid();
+		tester.testA_Z();
+		tester.testA_ZInvalid();
+		tester.testTypable();
+		tester.testTypableInvalid();
+	}
+
+	@Test
+	public void test_a_z() {
+		assertTrue(Text.a_z("abcdefghijklmnopqrstuvwxyz"));
+	}
+
+	@Test
+	public void test_a_zInvalid() {
+		assertFalse(Text.a_z("ABC"));
+	}
+
+	@Test
+	public void testA_Z() {
+		assertTrue(Text.A_Z("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+	}
+
+	@Test
+	public void testA_ZInvalid() {
+		assertFalse(Text.A_Z("abc"));
+	}
+
+	@Test
+	public void testTypable() {
+		assertTrue(Text.isTypable("!1@2#3$4%5^6&7*8(9)0_-+=QqWwEeRrTtYyUuIiOoPp{[}]|\\AaSsDdFfGgHhJjKkLl:;\"'ZzXxCcVvBbNnMm<,>.?/"));
+	}
+
+	@Test
+	public void testTypableInvalid() {
+		assertFalse(Text.isTypable("💩"));
+	}
+
+
+}

--- a/src/test/java/ZipperTest.java
+++ b/src/test/java/ZipperTest.java
@@ -1,0 +1,27 @@
+package test.java;
+
+import com.xarql.util.Zipper;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ZipperTest {
+
+	public static final File TEST_DIR = new File(".github");
+	public static final File TEST_OUTPUT_FILE = new File("target/test.zip");
+	public static final int TEST_ZIP_SIZE = 1632;
+
+	// test zipper by measuring size of output file
+	@Test
+	public void testZipperWithOutputPath() throws IOException {
+		final File output = Zipper.zip(TEST_DIR, TEST_OUTPUT_FILE);
+		final int zipLength = Files.readAllBytes(output.toPath()).length;
+		assertEquals(TEST_ZIP_SIZE, zipLength);
+	}
+
+}


### PR DESCRIPTION
These commits were made months ago, so the following summary might not be 100% accurate and complete. The code added looks good, so it's not going to waste.

Adds a test for the Zipper utility; using the .github folder as the source and testing for output file size.
Fixes the test for the BaseConverter utility;  properly testing the available range of bases and terminating the thread pool correctly.
Adds CoverageRunner; used to debug & grab coverage for multiple tests at once
Adds a test for the Text utilities
Adds .DS_Store to .gitignore (macOS needs to chill out)
